### PR TITLE
Pass replay rate to ymchip

### DIFF
--- a/StSoundLibrary/Ym2149Ex.h
+++ b/StSoundLibrary/Ym2149Ex.h
@@ -78,7 +78,7 @@ class	CDcAdjuster
 {
 public:
 	CDcAdjuster();
-	
+
 	void	AddSample(ymint sample);
 	ymint	GetDcLevel(void)			{ return m_sum / DC_ADJUST_BUFFERLEN; }
 	void	Reset(void);

--- a/StSoundLibrary/YmMusic.cpp
+++ b/StSoundLibrary/YmMusic.cpp
@@ -47,9 +47,9 @@ static	const ymint	mfpPrediv[8] = {0,4,10,16,50,64,100,200};
 
 
 
-CYmMusic::CYmMusic(ymint _replayRate)
+CYmMusic::CYmMusic(ymint _replayRate) :
+    ymChip(ATARI_CLOCK, 1, _replayRate)
 {
-
 	pBigMalloc = NULL;
 	pSongName = NULL;
 	pSongAuthor = NULL;


### PR DESCRIPTION
If a user would pass down different playing rate than 44100 Hz to `CYmMusic` (in my case 48000) the `ymChip` would still use 44100 as it's a default parameter to the `Ym2149Ex` constructor. Now we pass down this to the chip so the playing rate is the same. 