### PR TITLE
Add a way to set the rate in the C interface

### DIFF
--- a/StSoundLibrary/StSoundLibrary.h
+++ b/StSoundLibrary/StSoundLibrary.h
@@ -60,6 +60,7 @@ extern "C"
 
 // Create object
 extern	YMMUSIC *		ymMusicCreate();
+extern  YMMUSIC *		ymMusicCreateWithRate(ymint rate);
 
 // Release object
 extern	void			ymMusicDestroy(YMMUSIC *pMusic);

--- a/StSoundLibrary/YmUserInterface.cpp
+++ b/StSoundLibrary/YmUserInterface.cpp
@@ -46,6 +46,10 @@ YMMUSIC	* ymMusicCreate()
 	return (YMMUSIC*)(new CYmMusic);
 }
 
+YMMUSIC * ymMusicCreateWithRate(ymint rate)
+{
+	return (YMMUSIC*)(new CYmMusic(rate));
+}
 
 ymbool ymMusicLoad(YMMUSIC *pMus, const char *fName)
 {


### PR DESCRIPTION
I am compiling the library to WASM with Emscripten for this: https://nguillaumin.github.io/ym-jukebox/ . It uses a replay rate of 48000 Hz, so I would need a way to initialize StSoundLibrary with that frequency.